### PR TITLE
Refactor todo interactions for accessibility and robustness

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <div class="container">
     <header>
       <h1 class="title">Todo</h1>
-      <div onclick="changeTheme()" class="tgl-btn"></div>
+      <button id="theme-toggle" class="tgl-btn" aria-label="Change theme"></button>
     </header>
     <div class="type-todo">
       <div class="circle"></div>
@@ -23,11 +23,11 @@
     <div class="todos"></div>
     <div class="remarks">
       <div class="completedCount">0 items left</div>
-      <div onclick="clearCompleted()" class="clear">Clear Completed</div>
+      <button id="clear-completed" class="clear">Clear Completed</button>
       <div class="filter-container">
-        <div onclick="showAll()" class="filterActive">All</div>
-        <div onclick="filterActive()" class="filter2">Active</div>
-        <div onclick="filterCompleted()" class="filter3">Completed</div>
+        <button id="filter-all" class="filterActive">All</button>
+        <button id="filter-active" class="filter2">Active</button>
+        <button id="filter-completed" class="filter3">Completed</button>
       </div>
     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "todo-app-main",
+  "version": "1.0.0",
+  "description": "![Design preview for the Todo app coding challenge](./design/desktop-preview.jpg)",
+  "main": "script.js",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -39,7 +39,6 @@ function newTodo(todoObj) {
     });
 
     todoCross.textContent = "X";
-    todoCross.style.color = "grey";
     todoCross.addEventListener("click", function(){
         todoEl.remove();
         todos = todos.filter((t) => t.id !== todoObj.id);
@@ -80,26 +79,22 @@ function clearCompleted(){
 
 function showAll(){
     document.querySelectorAll(".todo").forEach((todo) => {
-        todo.style.display = "grid";
+        todo.classList.remove("hidden");
     });
 }
 
 function filterCompleted(){
     document.querySelectorAll(".todo").forEach((todo) => {
-        todo.style.display = "grid";
-        if (!todo.querySelector("input").checked) {
-            todo.style.display = "none";
-        }
-    })
+        const isCompleted = todo.querySelector("input").checked;
+        todo.classList.toggle("hidden", !isCompleted);
+    });
 }
 
 function filterActive(){
     document.querySelectorAll(".todo").forEach((todo) => {
-        todo.style.display = "grid";
-        if (todo.querySelector("input").checked) {
-            todo.style.display = "none";
-        }
-    })
+        const isCompleted = todo.querySelector("input").checked;
+        todo.classList.toggle("hidden", isCompleted);
+    });
 }
 
 // Sortable (Drag and drop library)

--- a/script.js
+++ b/script.js
@@ -1,68 +1,61 @@
 const todoInput = document.querySelector("#todo-input");
 const todosContainer = document.querySelector(".todos");
 const completedCount = document.querySelector(".completedCount");
+const themeToggle = document.querySelector("#theme-toggle");
+const clearButton = document.querySelector("#clear-completed");
+const filterAllButton = document.querySelector("#filter-all");
+const filterActiveButton = document.querySelector("#filter-active");
+const filterCompletedButton = document.querySelector("#filter-completed");
 
 let todos = [];
 
 todoInput.addEventListener("keyup", function(e){
-    if (e.key === "Enter" || e.keyCode === 13){
-        todos.push({ value: e.target.value, checked: false});
-        newTodo(e.target.value);
+    if (e.key === "Enter" && e.target.value.trim() !== ""){
+        const todo = { id: Date.now(), value: e.target.value.trim(), checked: false };
+        todos.push(todo);
+        newTodo(todo);
         todoInput.value = "";
         countCompleted();
     }
 });
 
-function newTodo(value) {
-    const todo = document.createElement("div");
+function newTodo(todoObj) {
+    const todoEl = document.createElement("div");
     const todoText = document.createElement("p");
     const todoCheckBox = document.createElement("input");
     const todoCheckBoxLabel = document.createElement("label");
     const todoCross = document.createElement("span");
 
-    let obj = todos.find((t) => t.value === value);
-
-
-    todoText.textContent = value;
+    todoText.textContent = todoObj.value;
     todoCheckBox.type = "checkbox";
-    todoCheckBox.name = "checkbox";
-    todoCheckBoxLabel.htmlFor = "checkbox";
-    todoCheckBoxLabel.addEventListener("click", function (e){
-        if (todoCheckBox.checked){
-            todoCheckBox.checked = false;
-            todoText.style.textDecoration = "none";
-            todoText.style.color= "var(--tgl-txt-active)";
-            todoCheckBoxLabel.classList.remove("active");
-            obj.checked = false;
-            countCompleted();
-        } else {
-            obj.checked = true;
-            countCompleted();
-            todoCheckBox.checked = true;
-            todoText.style.textDecoration = "line-through";
-            todoText.style.color= "var(--tgl-txt-check)";
-            todoCheckBoxLabel.classList.add("active");
-        }
-    });
-
-    todoCross.textContent = "X";
-    todoCross.style.color = "grey"
-    todoCross.addEventListener("click", function(e){
-        e.target.parentElement.remove();
-        todos = todos.filter((t) => t !== obj);
+    const checkboxId = `todo-${todoObj.id}`;
+    todoCheckBox.id = checkboxId;
+    todoCheckBoxLabel.htmlFor = checkboxId;
+    todoCheckBox.addEventListener("change", function (){
+        todoEl.classList.toggle("completed", todoCheckBox.checked);
+        todoCheckBoxLabel.classList.toggle("active", todoCheckBox.checked);
+        todoObj.checked = todoCheckBox.checked;
         countCompleted();
     });
 
-    todo.classList.add("todo");
+    todoCross.textContent = "X";
+    todoCross.style.color = "grey";
+    todoCross.addEventListener("click", function(){
+        todoEl.remove();
+        todos = todos.filter((t) => t.id !== todoObj.id);
+        countCompleted();
+    });
+
+    todoEl.classList.add("todo");
     todoCheckBoxLabel.classList.add("circle");
     todoCross.classList.add("cross");
 
-    todo.appendChild(todoCheckBox);
-    todo.appendChild(todoCheckBoxLabel);
-    todo.appendChild(todoText);
-    todo.appendChild(todoCross);
-    
-    todosContainer.appendChild(todo);
+    todoEl.appendChild(todoCheckBox);
+    todoEl.appendChild(todoCheckBoxLabel);
+    todoEl.appendChild(todoText);
+    todoEl.appendChild(todoCross);
+
+    todosContainer.appendChild(todoEl);
 }
 
 function countCompleted(){
@@ -80,14 +73,15 @@ function clearCompleted(){
         if (todo.querySelector("input").checked){
             todo.remove();
         }
-    })
+    });
+    todos = todos.filter((t) => !t.checked);
+    countCompleted();
 }
 
 function showAll(){
-    document.querySelectorAll(".filter")
     document.querySelectorAll(".todo").forEach((todo) => {
         todo.style.display = "grid";
-    })
+    });
 }
 
 function filterCompleted(){
@@ -114,3 +108,9 @@ Sortable.create(todosContainer, {
     animation: 150,
     dragClass: "ghost"
 });
+
+themeToggle.addEventListener("click", changeTheme);
+clearButton.addEventListener("click", clearCompleted);
+filterAllButton.addEventListener("click", showAll);
+filterActiveButton.addEventListener("click", filterActive);
+filterCompletedButton.addEventListener("click", filterCompleted);

--- a/style.css
+++ b/style.css
@@ -68,6 +68,8 @@ header{
     background-size: cover;
     width: 30px;
     height: 30px;
+    border: none;
+    cursor: pointer;
 }
 .type-todo{
     width: 100%;
@@ -128,6 +130,11 @@ header{
 }
 .todo p{
     margin-left: 5px;
+    color: var(--tgl-txt-active);
+}
+.todo.completed p{
+    text-decoration: line-through;
+    color: var(--tgl-txt-check);
 }
 .active{
     position: relative;
@@ -157,7 +164,7 @@ header{
     border-radius: 0 0 5px 5px;
     box-shadow: 0px 10px 20px -3px var(--bx-shdw);
 }
-.remarks div{
+.remarks div, .remarks button{
     padding: 0 10px;
 }
 .filter-container{
@@ -176,6 +183,10 @@ header{
 }
 .filterActive, .filter2, .filter3, .clear{
     cursor: pointer;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
 }
 .text{
     position: relative;

--- a/style.css
+++ b/style.css
@@ -125,6 +125,9 @@ header{
     border-bottom: 1px solid var(--lg-todo); 
     box-shadow: 0px 0px 0px var(--bx-shdw);
 }
+.hidden{
+    display: none;
+}
 .todo input[type="checkbox"]{
     display: none;
 }
@@ -151,6 +154,7 @@ header{
 }
 .cross{
     cursor: pointer;
+    color: grey;
 }
 .remarks{
     width: 100%;


### PR DESCRIPTION
## Summary
- replace inline `onclick` handlers with semantic buttons and JS listeners
- assign unique IDs to todos and toggle CSS classes instead of inline styles
- keep todo list and counter in sync when clearing completed tasks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8319abf08333894998a944e2c4f0